### PR TITLE
Updated pulled_metadata_asianbarometer.json

### DIFF
--- a/src/synthetic_sampling/profiles/metadata/asainbarometer/pulled_metadata_asianbarometer.json
+++ b/src/synthetic_sampling/profiles/metadata/asainbarometer/pulled_metadata_asianbarometer.json
@@ -4,7 +4,6 @@
     "wave": 6,
     "description": "Core questionnaire metadata"
   },
-  "sections": {
     "demographics": {
       "country": {
         "description": "country of residence",
@@ -1609,8 +1608,7 @@
         "question": "To you, what does 'democracy' mean?",
         "values": {},
         "notes": "Optional open-ended question. String variable excluded from metadata."
-      }
-    },
+      },
     "satisfaction_with_government_and_democracy": {
       "Q90": {
         "description": "satisfaction with how democracy works",
@@ -3367,7 +3365,6 @@
       }
     },
     "socioeconomic_background": {
-      },
       "SE2": {
         "description": "respondent's gender",
         "question": "What is your gender?",
@@ -4349,5 +4346,5 @@
         "notes": "Optional question."
       }
     }
-
+}
 

--- a/src/synthetic_sampling/profiles/metadata/asainbarometer/pulled_metadata_asianbarometer.json
+++ b/src/synthetic_sampling/profiles/metadata/asainbarometer/pulled_metadata_asianbarometer.json
@@ -1,9 +1,4 @@
 {
-  "survey_info": {
-    "name": "Asian Barometer Survey of Democracy, Governance and Development",
-    "wave": 6,
-    "description": "Core questionnaire metadata"
-  },
     "demographics": {
       "country": {
         "description": "country of residence",


### PR DESCRIPTION
Removed empty Section header from the Asian Barometer metadata.

Removed extra {} from Socioeconomic header

Note... still issues with Generator not running correctly.

Getting this error "The AttributeError: 'str' object has no attribute 'get' indicates that the RespondentProfileGenerator is still encountering parts of your metadata where it expects a dictionary containing question details (like 'question' and 'description' keys), but it's finding a plain string instead. "